### PR TITLE
Add log sampling rate feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,11 @@ jobs:
     name: OTP ${{matrix.otp}} / rebar3 ${{matrix.rebar3}}
     strategy:
       matrix:
-        otp: ["22.3", "23.3", "24.2"]
-        rebar3: ["3.18.0"]
+        otp: ["25.3"]
+        rebar3: ["3.24.0"]
     steps:
-      - uses: actions/checkout@v2
-      - uses: erlef/setup-beam@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9 # v1.20.4
         with:
           otp-version: ${{matrix.otp}}
           rebar3-version: ${{matrix.rebar3}}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Add arbitrary logger configurations:
                            buz_logger,
                            [{event, buz},
                             {file, "log/buz.log"},
-                            {maxbytes, infinity} %% no limit no file size
+                            {maxbytes, infinity}, %% no limit no file size
+                            {sampling_rate, 0.1} %% 10% of logs are written
                            ]}
                          ]}
               ]}
@@ -47,9 +48,9 @@ Add arbitrary logger configurations:
 Write events:
 
 ```
-eventlogger:write(foo, <<"Hello log/foo.log">>).
-eventlogger:write(bar, <<"Hi log/bar.log">>).
-eventlogger:write(buz, <<"Hi log/buz.log">>).
+eventlogger:log(foo, <<"Hello log/foo.log">>).
+eventlogger:log(bar, <<"Hi log/bar.log">>).
+eventlogger:log(buz, <<"Hi log/buz.log">>).
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,14 @@ Add arbitrary logger configurations:
 
 Write events:
 
-```
+```erlang
+%% Write all logs (subject to handler's sampling_rate)
 eventlogger:log(foo, <<"Hello log/foo.log">>).
-eventlogger:log(bar, <<"Hi log/bar.log">>).
-eventlogger:log(buz, <<"Hi log/buz.log">>).
+
+%% Write with explicit sampling rate (compounds with handler's sampling_rate)
+%% If handler's sampling_rate is 0.1 and we call log/3 with 0.1, 
+%% the final output rate will be 1% (0.01).
+eventlogger:log(bar, <<"Hi log/bar.log">>, 0.1).
 ```
 
 

--- a/config/sys.config
+++ b/config/sys.config
@@ -26,7 +26,8 @@
                             buz_logger,
                             [{event, buz},
                              {file, "_var/buz.log"},
-                             {maxbytes, infinity} %% no size limit on file
+                             {maxbytes, infinity}, %% no size limit on file
+                             {sampling_rate, 0.1}
                             ]}
                           ]}
                ]}

--- a/src/eventlogger.app.src
+++ b/src/eventlogger.app.src
@@ -1,6 +1,6 @@
 {application, eventlogger,
  [{description, "An OTP application"},
-  {vsn, "0.1.0"},
+  {vsn, "0.0.3"},
   {registered, []},
   {mod, {eventlogger_app, []}},
   {applications,

--- a/src/eventlogger.erl
+++ b/src/eventlogger.erl
@@ -1,6 +1,6 @@
 -module(eventlogger).
 
--export([format/3, log/2]).
+-export([format/3, log/2, log/3]).
 
 -spec format(Event :: atom(), Format :: string(), Args :: [term()]) -> ok.
 format(Event, Format, Args) ->
@@ -11,3 +11,12 @@ log(Event, Output) when is_list(Output) ->
     log(Event, unicode:characters_to_binary(Output));
 log(Event, Output) ->
     eventlogger_sup:notify(Event, Output).
+
+-spec log(Event :: atom(), Output :: binary()|string(), Rate :: float()) -> ok.
+log(Event, Output, Rate) ->
+    case eventlogger_utils:is_sampled(Rate) of
+        true ->
+            log(Event, Output);
+        _ ->
+            ok
+    end.

--- a/src/eventlogger_file_writer.erl
+++ b/src/eventlogger_file_writer.erl
@@ -19,6 +19,7 @@
          maxbytes = infinity :: maxbytes(),
          count = infinity :: count(),
          delimiter = <<"\n">> :: binary(),
+         sampling_rate = 1.0 :: float(),
          io = undefined :: io() | undefined,
          wbytes = 0 :: integer()}).
 
@@ -33,7 +34,8 @@
      {modes, [file:mode()]} |
      {maxbytes, maxbytes()} |
      {count, count()} |
-     {delimiter, binary()}].
+     {delimiter, binary()} |
+     {sampling_rate, float()}].
 
 -spec init(Args :: args()) -> {ok, state()}.
 init(Args) ->
@@ -50,6 +52,8 @@ init(Args) ->
                             Acc#state{count = V};
                         ({delimiter, V}, Acc) ->
                             Acc#state{delimiter = V};
+                        ({sampling_rate, V}, Acc) ->
+                            Acc#state{sampling_rate = float(V)};
                         (_, Acc) ->
                             Acc
                     end,
@@ -76,6 +80,7 @@ handle_call(dump_state, State) ->
        maxbytes => State#state.maxbytes,
        count => State#state.count,
        delimiter => State#state.delimiter,
+       sampling_rate => State#state.sampling_rate,
        io => State#state.io,
        wbytes => State#state.wbytes},
      State};
@@ -83,19 +88,24 @@ handle_call(Req, State) ->
     ?LOG_WARNING("unhandled call (~p, ~p)", [Req, State]),
     {ok, {error, {unhandled_call, Req}}, State}.
 
-handle_event({Event, Output} = Req, #state{event = Event} = State) ->
-    case ensure_file(State) of
-        {ok, {Io, WrittenBytes}} ->
-            case write_to_file(Output, State#state{io = Io, wbytes = WrittenBytes}) of
-                {ok, NewState} ->
-                    {ok, NewState};
-                {error, Reason2} ->
-                    ?LOG_ERROR("failed writing to file: ~p (~p, ~p)", [Reason2, Req, State]),
+handle_event({Event, Output} = Req, #state{event = Event, sampling_rate = Rate} = State) ->
+    case rand:uniform() < Rate of
+        true ->
+            case ensure_file(State) of
+                {ok, {Io, WrittenBytes}} ->
+                    case write_to_file(Output, State#state{io = Io, wbytes = WrittenBytes}) of
+                        {ok, NewState} ->
+                            {ok, NewState};
+                        {error, Reason2} ->
+                            ?LOG_ERROR("failed writing to file: ~p (~p, ~p)", [Reason2, Req, State]),
+                            remove_handler
+                    end;
+                {error, Reason1} ->
+                    ?LOG_ERROR("failed ensuring an open file: ~p (~p, ~p)", [Reason1, Req, State]),
                     remove_handler
             end;
-        {error, Reason1} ->
-            ?LOG_ERROR("failed ensuring an open file: ~p (~p, ~p)", [Reason1, Req, State]),
-            remove_handler
+        false ->
+            {ok, State}
     end;
 handle_event(_Event, State) ->
     {ok, State}.

--- a/src/eventlogger_file_writer.erl
+++ b/src/eventlogger_file_writer.erl
@@ -89,7 +89,7 @@ handle_call(Req, State) ->
     {ok, {error, {unhandled_call, Req}}, State}.
 
 handle_event({Event, Output} = Req, #state{event = Event, sampling_rate = Rate} = State) ->
-    case rand:uniform() =< Rate of
+    case eventlogger_utils:is_sampled(Rate) of
         true ->
             case ensure_file(State) of
                 {ok, {Io, WrittenBytes}} ->

--- a/src/eventlogger_file_writer.erl
+++ b/src/eventlogger_file_writer.erl
@@ -89,7 +89,7 @@ handle_call(Req, State) ->
     {ok, {error, {unhandled_call, Req}}, State}.
 
 handle_event({Event, Output} = Req, #state{event = Event, sampling_rate = Rate} = State) ->
-    case rand:uniform() < Rate of
+    case rand:uniform() =< Rate of
         true ->
             case ensure_file(State) of
                 {ok, {Io, WrittenBytes}} ->

--- a/src/eventlogger_utils.erl
+++ b/src/eventlogger_utils.erl
@@ -1,0 +1,11 @@
+-module(eventlogger_utils).
+
+-export([is_sampled/1]).
+
+-spec is_sampled(float()) -> boolean().
+is_sampled(Rate) when Rate =< 0.0 ->
+    false;
+is_sampled(Rate) when Rate >= 1.0 ->
+    true;
+is_sampled(Rate) ->
+    rand:uniform() =< Rate.

--- a/test/eventlogger_sampling_tests.erl
+++ b/test/eventlogger_sampling_tests.erl
@@ -1,0 +1,101 @@
+-module(eventlogger_sampling_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+sampling_rate_1_test_() ->
+    {setup,
+     fun() ->
+        {ok, TmpDir} = eventlogger_util:tmpdir(["/tmp/", ?MODULE]),
+        {ok, Pid} = gen_event:start_link(),
+        LogFile = [TmpDir, "/sampling_1.log"],
+        ok =
+            gen_event:add_handler(Pid,
+                                  {eventlogger_file_writer, 1},
+                                  [{event, foo},
+                                   {file, LogFile},
+                                   {modes, [append, raw, write]},
+                                   {sampling_rate, 1.0}]),
+        [{tmpdir, TmpDir}, {logfile, LogFile}, {gen_event, Pid}]
+     end,
+     fun(Args) ->
+        Pid = proplists:get_value(gen_event, Args),
+        gen_event:stop(Pid)
+     end,
+     fun(Args) ->
+        LogFile = proplists:get_value(logfile, Args),
+        Pid = proplists:get_value(gen_event, Args),
+        [{"sampling_rate 1.0 writes all logs",
+          fun() ->
+             [ ok = gen_event:sync_notify(Pid, {foo, <<"log">>}) || _ <- lists:seq(1, 100) ],
+             {ok, Data} = file:read_file(LogFile),
+             Lines = binary:split(Data, <<"
+">>, [global, trim]),
+             ?assertEqual(100, length(Lines))
+          end}]
+     end}.
+
+sampling_rate_0_test_() ->
+    {setup,
+     fun() ->
+        {ok, TmpDir} = eventlogger_util:tmpdir(["/tmp/", ?MODULE]),
+        {ok, Pid} = gen_event:start_link(),
+        LogFile = [TmpDir, "/sampling_0.log"],
+        ok =
+            gen_event:add_handler(Pid,
+                                  {eventlogger_file_writer, 1},
+                                  [{event, foo},
+                                   {file, LogFile},
+                                   {modes, [append, raw, write]},
+                                   {sampling_rate, 0.0}]),
+        [{tmpdir, TmpDir}, {logfile, LogFile}, {gen_event, Pid}]
+     end,
+     fun(Args) ->
+        Pid = proplists:get_value(gen_event, Args),
+        gen_event:stop(Pid)
+     end,
+     fun(Args) ->
+        LogFile = proplists:get_value(logfile, Args),
+        Pid = proplists:get_value(gen_event, Args),
+        [{"sampling_rate 0.0 writes no logs",
+          fun() ->
+             [ ok = gen_event:sync_notify(Pid, {foo, <<"log">>}) || _ <- lists:seq(1, 100) ],
+             {ok, Data} = file:read_file(LogFile),
+             ?assertEqual(<<>>, Data)
+          end}]
+     end}.
+
+sampling_rate_half_test_() ->
+    {setup,
+     fun() ->
+        {ok, TmpDir} = eventlogger_util:tmpdir(["/tmp/", ?MODULE]),
+        {ok, Pid} = gen_event:start_link(),
+        LogFile = [TmpDir, "/sampling_half.log"],
+        ok =
+            gen_event:add_handler(Pid,
+                                  {eventlogger_file_writer, 1},
+                                  [{event, foo},
+                                   {file, LogFile},
+                                   {modes, [append, raw, write]},
+                                   {sampling_rate, 0.5}]),
+        [{tmpdir, TmpDir}, {logfile, LogFile}, {gen_event, Pid}]
+     end,
+     fun(Args) ->
+        Pid = proplists:get_value(gen_event, Args),
+        gen_event:stop(Pid)
+     end,
+     fun(Args) ->
+        LogFile = proplists:get_value(logfile, Args),
+        Pid = proplists:get_value(gen_event, Args),
+        [{"sampling_rate 0.5 writes approx 50% logs",
+          fun() ->
+             Count = 1000,
+             [ ok = gen_event:sync_notify(Pid, {foo, <<"log">>}) || _ <- lists:seq(1, Count) ],
+             {ok, Data} = file:read_file(LogFile),
+             Lines = binary:split(Data, <<"
+">>, [global, trim]),
+             Len = length(Lines),
+             %% Over 1000 samples, 0.5 should be within [400, 600] with very high probability
+             ?assert(Len > 400),
+             ?assert(Len < 600)
+          end}]
+     end}.

--- a/test/eventlogger_sampling_tests.erl
+++ b/test/eventlogger_sampling_tests.erl
@@ -99,3 +99,39 @@ sampling_rate_half_test_() ->
              ?assert(Len < 600)
           end}]
      end}.
+
+log_sampling_test_() ->
+    {setup,
+     fun() ->
+        {ok, TmpDir} = eventlogger_util:tmpdir(["/tmp/", ?MODULE]),
+        {ok, Pid} = gen_event:start_link({local, eventlogger_manager}),
+        LogFile = [TmpDir, "/log_sampling.log"],
+        ok =
+            gen_event:add_handler(Pid,
+                                  {eventlogger_file_writer, 1},
+                                  [{event, foo},
+                                   {file, LogFile},
+                                   {modes, [append, raw, write]},
+                                   {sampling_rate, 1.0}]),
+        [{tmpdir, TmpDir}, {logfile, LogFile}, {gen_event, Pid}]
+     end,
+     fun(Args) ->
+        Pid = proplists:get_value(gen_event, Args),
+        gen_event:stop(Pid)
+     end,
+     fun(Args) ->
+        LogFile = proplists:get_value(logfile, Args),
+        [{"eventlogger:log/3 with 0.0 writes nothing",
+          fun() ->
+             [ ok = eventlogger:log(foo, <<"log">>, 0.0) || _ <- lists:seq(1, 100) ],
+             {ok, Data} = file:read_file(LogFile),
+             ?assertEqual(<<>>, Data)
+          end},
+         {"eventlogger:log/3 with 1.0 writes all",
+          fun() ->
+             [ ok = eventlogger:log(foo, <<"log">>, 1.0) || _ <- lists:seq(1, 100) ],
+             {ok, Data} = file:read_file(LogFile),
+             Lines = binary:split(Data, <<"\n">>, [global, trim]),
+             ?assertEqual(100, length(Lines))
+          end}]
+     end}.


### PR DESCRIPTION
This pull request adds log sampling support both at the handler level (via config) and the call-site (via `log/3`), providing flexible control over logging volume.

### Key Changes
- **Handler Configuration**: Added a new `sampling_rate` config for `eventlogger_file_writer`. It can be set for each handler in your configuration. ⚙️
- **New API Function**: Added `eventlogger:log/3` which accepts an explicit `sampling_rate` as the third parameter. 📈
- **Compound Sampling**: Sampling rates now compound if both the call-site and the handler have a rate set (e.g., 0.1 at call-site * 0.1 at handler = 0.01 final rate). 🔄
- **Optimization**: Introduced `eventlogger_utils:is_sampled/1` to optimize sampling logic. It skips `rand:uniform/0` calls for rates `<= 0.0` or `>= 1.0` to save cycles. 🏎️
- **Refactoring**: Moved shared sampling logic into `src/eventlogger_utils.erl` to maintain clean dependencies.
- **CI/CD**: Updated `.github/workflows/ci.yml` to use **OTP 25.3** and **rebar3 3.24.0**, and bumped `actions/checkout` to `v4`. 🛠️
- **Documentation**: Updated `README.md` with examples and an explanation of the compounding sampling behavior.
- **Testing**: Added comprehensive tests in `test/eventlogger_sampling_tests.erl` for various sampling scenarios, including the new `log/3` functionality. 🧪

### Example Configuration:
```erlang
{eventlogger_file_writer,
 buz_logger,
 [{event, buz},
  {file, "log/buz.log"},
  {sampling_rate, 0.1} %% 10% of logs are written
 ]}
```

### Example Usage:
```erlang
%% Explicitly log 10% of these events (compounds with handler's rate)
eventlogger:log(foo, <<"Some noisy log">>, 0.1).
```
