### PR TITLE
perf: F29/F6 reqres/eventlogger の直列コスト削減

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ Add arbitrary logger configurations:
                             {file, "log/buz.log"},
                             {maxbytes, infinity}, %% no limit no file size
                             {sampling_rate, 0.1} %% 10% of logs are written
+                           ]},
+                          {eventlogger_file_writer,
+                           qux_logger,
+                           [{event, qux},
+                            {file, "log/qux.log"},
+                            {maxbytes, infinity},
+                            %% how often (ms) to check for an externally
+                            %% rotated/replaced file; defaults to 1000
+                            {check_interval, 5000}
                            ]}
                          ]}
               ]}

--- a/src/eventlogger.app.src
+++ b/src/eventlogger.app.src
@@ -1,6 +1,6 @@
 {application, eventlogger,
  [{description, "An OTP application"},
-  {vsn, "0.0.3"},
+  {vsn, "0.0.4"},
   {registered, []},
   {mod, {eventlogger_app, []}},
   {applications,

--- a/src/eventlogger_file_writer.erl
+++ b/src/eventlogger_file_writer.erl
@@ -97,6 +97,7 @@ handle_call(dump_state, State) ->
        delimiter => State#state.delimiter,
        sampling_rate => State#state.sampling_rate,
        check_interval => State#state.check_interval,
+       timer_ref => State#state.timer_ref,
        io => State#state.io,
        wbytes => State#state.wbytes},
      State};
@@ -123,7 +124,16 @@ handle_event(_Event, State) ->
 %% Periodic, decoupled-from-writes check for an externally rotated/replaced
 %% file (F6). Runs on ?DEFAULT_CHECK_INTERVAL (or the configured
 %% check_interval) instead of on every handle_event/2 call.
-handle_info(?CHECK_FILE_CHANGED, State) ->
+%%
+%% Several eventlogger_file_writer instances (e.g. rtb_v2_log and
+%% req_res_log) are typically installed on the SAME gen_event manager, which
+%% broadcasts any raw message (including our timer message) to every
+%% installed handler's handle_info/2, not just the one that scheduled it.
+%% erlang:start_timer/3 embeds a fresh reference in the delivered
+%% {timeout, Ref, _} message, so we can tell "this is the check I scheduled"
+%% (Ref matches our own timer_ref) apart from another handler's timer (or a
+%% stale one of our own) and ignore the latter without rescheduling.
+handle_info({timeout, Ref, ?CHECK_FILE_CHANGED}, #state{timer_ref = Ref} = State) ->
     NewState =
         case ensure_file(State) of
             {ok, {Io, WrittenBytes}} ->
@@ -133,6 +143,10 @@ handle_info(?CHECK_FILE_CHANGED, State) ->
                 State
         end,
     {ok, schedule_check(NewState)};
+handle_info({timeout, _OtherRef, ?CHECK_FILE_CHANGED}, State) ->
+    %% Belongs to a different handler instance on the same manager (or a
+    %% stale timer of our own); we already have our own timer pending.
+    {ok, State};
 handle_info(Info, State) ->
     ?LOG_WARNING("unhandled info (~p, ~p)", [Info, State]),
     {ok, State}.
@@ -140,7 +154,7 @@ handle_info(Info, State) ->
 %% private funs
 -spec schedule_check(State :: state()) -> state().
 schedule_check(#state{check_interval = Interval} = State) ->
-    TimerRef = erlang:send_after(Interval, self(), ?CHECK_FILE_CHANGED),
+    TimerRef = erlang:start_timer(Interval, self(), ?CHECK_FILE_CHANGED),
     State#state{timer_ref = TimerRef}.
 
 -spec cancel_check(TimerRef :: reference() | undefined) -> ok.

--- a/src/eventlogger_file_writer.erl
+++ b/src/eventlogger_file_writer.erl
@@ -156,15 +156,18 @@ write_to_file(Output0,
                      io = {IoDevice0, _} = Io0,
                      wbytes = WrittenBytes0} =
                   State) ->
-    Output = <<Output0/binary, Delimiter/binary>>,
-    case file:write(IoDevice0, Output) of
+    %% Pass iodata straight to file:write/2 instead of concatenating into a
+    %% new binary first -- avoids copying the whole (often multi-KB) Output0
+    %% just to append a delimiter.
+    OutputSize = byte_size(Output0) + byte_size(Delimiter),
+    case file:write(IoDevice0, [Output0, Delimiter]) of
         ok ->
             Result =
                 case MaxBytes of
                     infinity ->
-                        {ok, {Io0, WrittenBytes0 + byte_size(Output)}};
+                        {ok, {Io0, WrittenBytes0 + OutputSize}};
                     _ ->
-                        CurWrittenBytes = WrittenBytes0 + byte_size(Output),
+                        CurWrittenBytes = WrittenBytes0 + OutputSize,
                         case CurWrittenBytes < MaxBytes of
                             true ->
                                 {ok, {Io0, CurWrittenBytes}};

--- a/src/eventlogger_file_writer.erl
+++ b/src/eventlogger_file_writer.erl
@@ -181,11 +181,20 @@ open_file(State) ->
     end.
 
 -spec ensure_file(State :: state()) -> {ok, {io(), non_neg_integer()}} | {error, term()}.
-ensure_file(#state{file = File, io = {_, Inode0}} = State) ->
+ensure_file(#state{file = File, io = {OldIoDevice, Inode0}} = State) ->
     case is_file_changed(File, Inode0) of
         true ->
             ?LOG_DEBUG("(~p) detected file change on ~ts", [File]),
-            open_file(State);
+            %% Close the old fd only after a new one is confirmed open, so a
+            %% failed reopen leaves the (still valid) old fd in place rather
+            %% than dropping to zero open file handles.
+            case open_file(State) of
+                {ok, _} = Result ->
+                    eventlogger_file_rotator:close(OldIoDevice),
+                    Result;
+                Err ->
+                    Err
+            end;
         _ ->
             {ok, {State#state.io, State#state.wbytes}}
     end.

--- a/src/eventlogger_file_writer.erl
+++ b/src/eventlogger_file_writer.erl
@@ -84,7 +84,7 @@ init(Args) ->
 terminate(Reason, #state{io = {IoDevice, _}, timer_ref = TimerRef} = State) ->
     ?LOG_INFO("terminate (~p, ~p)", [Reason, State]),
     cancel_check(TimerRef),
-    file:close(IoDevice),
+    eventlogger_file_rotator:close(IoDevice),
     ok.
 
 handle_call(dump_state, State) ->

--- a/src/eventlogger_file_writer.erl
+++ b/src/eventlogger_file_writer.erl
@@ -11,6 +11,15 @@
 -define(DEFAULT_SYNC_INTERVAL, 1000).
 -define(DEFAULT_SYNC_SIZE, 1024 * 64). %% 64kb
 
+%% F6: detecting an externally-rotated/replaced file (e.g. by logrotate or a
+%% symlink swap) requires stat'ing the file via file:read_file_info/2. Doing
+%% this on every single event serializes an extra syscall per log line
+%% through the single gen_event process. Instead, the check runs on a timer
+%% and its result is cached in state; handle_event/2 always writes through
+%% the cached io without stat'ing first.
+-define(DEFAULT_CHECK_INTERVAL, 1000). %% ms
+-define(CHECK_FILE_CHANGED, '$eventlogger_check_file_changed').
+
 -record(state,
         {event = default :: atom(),
          file = undefined :: file:name_all() | undefined,
@@ -20,6 +29,8 @@
          count = infinity :: count(),
          delimiter = <<"\n">> :: binary(),
          sampling_rate = 1.0 :: float(),
+         check_interval = ?DEFAULT_CHECK_INTERVAL :: non_neg_integer(),
+         timer_ref = undefined :: reference() | undefined,
          io = undefined :: io() | undefined,
          wbytes = 0 :: integer()}).
 
@@ -35,7 +46,8 @@
      {maxbytes, maxbytes()} |
      {count, count()} |
      {delimiter, binary()} |
-     {sampling_rate, float()}].
+     {sampling_rate, float()} |
+     {check_interval, non_neg_integer()}].
 
 -spec init(Args :: args()) -> {ok, state()}.
 init(Args) ->
@@ -54,6 +66,8 @@ init(Args) ->
                             Acc#state{delimiter = V};
                         ({sampling_rate, V}, Acc) ->
                             Acc#state{sampling_rate = float(V)};
+                        ({check_interval, V}, Acc) ->
+                            Acc#state{check_interval = V};
                         (_, Acc) ->
                             Acc
                     end,
@@ -61,14 +75,15 @@ init(Args) ->
                     Args),
     case open_file(State) of
         {ok, {Io, WrittenBytes}} ->
-            {ok, State#state{io = Io, wbytes = WrittenBytes}};
+            {ok, schedule_check(State#state{io = Io, wbytes = WrittenBytes})};
         Err ->
             Err
     end.
 
 -spec terminate(Reason :: term(), State :: state()) -> ok.
-terminate(Reason, #state{io = {IoDevice, _}} = State) ->
+terminate(Reason, #state{io = {IoDevice, _}, timer_ref = TimerRef} = State) ->
     ?LOG_INFO("terminate (~p, ~p)", [Reason, State]),
+    cancel_check(TimerRef),
     file:close(IoDevice),
     ok.
 
@@ -81,6 +96,7 @@ handle_call(dump_state, State) ->
        count => State#state.count,
        delimiter => State#state.delimiter,
        sampling_rate => State#state.sampling_rate,
+       check_interval => State#state.check_interval,
        io => State#state.io,
        wbytes => State#state.wbytes},
      State};
@@ -91,17 +107,11 @@ handle_call(Req, State) ->
 handle_event({Event, Output} = Req, #state{event = Event, sampling_rate = Rate} = State) ->
     case eventlogger_utils:is_sampled(Rate) of
         true ->
-            case ensure_file(State) of
-                {ok, {Io, WrittenBytes}} ->
-                    case write_to_file(Output, State#state{io = Io, wbytes = WrittenBytes}) of
-                        {ok, NewState} ->
-                            {ok, NewState};
-                        {error, Reason2} ->
-                            ?LOG_ERROR("failed writing to file: ~p (~p, ~p)", [Reason2, Req, State]),
-                            remove_handler
-                    end;
-                {error, Reason1} ->
-                    ?LOG_ERROR("failed ensuring an open file: ~p (~p, ~p)", [Reason1, Req, State]),
+            case write_to_file(Output, State) of
+                {ok, NewState} ->
+                    {ok, NewState};
+                {error, Reason} ->
+                    ?LOG_ERROR("failed writing to file: ~p (~p, ~p)", [Reason, Req, State]),
                     remove_handler
             end;
         false ->
@@ -110,11 +120,36 @@ handle_event({Event, Output} = Req, #state{event = Event, sampling_rate = Rate} 
 handle_event(_Event, State) ->
     {ok, State}.
 
+%% Periodic, decoupled-from-writes check for an externally rotated/replaced
+%% file (F6). Runs on ?DEFAULT_CHECK_INTERVAL (or the configured
+%% check_interval) instead of on every handle_event/2 call.
+handle_info(?CHECK_FILE_CHANGED, State) ->
+    NewState =
+        case ensure_file(State) of
+            {ok, {Io, WrittenBytes}} ->
+                State#state{io = Io, wbytes = WrittenBytes};
+            {error, Reason} ->
+                ?LOG_ERROR("failed ensuring an open file: ~p (~p)", [Reason, State]),
+                State
+        end,
+    {ok, schedule_check(NewState)};
 handle_info(Info, State) ->
     ?LOG_WARNING("unhandled info (~p, ~p)", [Info, State]),
     {ok, State}.
 
 %% private funs
+-spec schedule_check(State :: state()) -> state().
+schedule_check(#state{check_interval = Interval} = State) ->
+    TimerRef = erlang:send_after(Interval, self(), ?CHECK_FILE_CHANGED),
+    State#state{timer_ref = TimerRef}.
+
+-spec cancel_check(TimerRef :: reference() | undefined) -> ok.
+cancel_check(undefined) ->
+    ok;
+cancel_check(TimerRef) ->
+    erlang:cancel_timer(TimerRef),
+    ok.
+
 -spec open_file(State :: state()) -> {ok, {io(), non_neg_integer()}} | {error, term()}.
 open_file(State) ->
     case eventlogger_file_rotator:open(State#state.file,

--- a/src/eventlogger_file_writer.erl
+++ b/src/eventlogger_file_writer.erl
@@ -154,7 +154,9 @@ handle_info(Info, State) ->
 %% private funs
 -spec schedule_check(State :: state()) -> state().
 schedule_check(#state{check_interval = Interval} = State) ->
-    TimerRef = erlang:start_timer(Interval, self(), ?CHECK_FILE_CHANGED),
+    %% Clamp to avoid a tight reschedule loop (CPU spike) if check_interval
+    %% is misconfigured to 0 or a negative value in sys.config.
+    TimerRef = erlang:start_timer(max(1, Interval), self(), ?CHECK_FILE_CHANGED),
     State#state{timer_ref = TimerRef}.
 
 -spec cancel_check(TimerRef :: reference() | undefined) -> ok.

--- a/src/eventlogger_file_writer.erl
+++ b/src/eventlogger_file_writer.erl
@@ -184,7 +184,7 @@ open_file(State) ->
 ensure_file(#state{file = File, io = {OldIoDevice, Inode0}} = State) ->
     case is_file_changed(File, Inode0) of
         true ->
-            ?LOG_DEBUG("(~p) detected file change on ~ts", [File]),
+            ?LOG_DEBUG("detected file change on ~ts", [File]),
             %% Close the old fd only after a new one is confirmed open, so a
             %% failed reopen leaves the (still valid) old fd in place rather
             %% than dropping to zero open file handles.

--- a/test/eventlogger_file_writer_tests.erl
+++ b/test/eventlogger_file_writer_tests.erl
@@ -15,7 +15,12 @@ handler_with_maxbytes_test_() ->
                                    {file, LogFile},
                                    {modes, [append, raw, write]},
                                    {maxbytes, 15},
-                                   {count, 2}]),
+                                   {count, 2},
+                                   %% Long enough that the real timer never
+                                   %% fires during this test; the vanished/
+                                   %% recreated cases below trigger the
+                                   %% check explicitly instead.
+                                   {check_interval, 60000}]),
         [{tmpdir, TmpDir}, {logfile, LogFile}, {gen_event, Pid}]
      end,
      fun(Args) ->
@@ -58,7 +63,13 @@ handler_with_maxbytes_test_() ->
               end},
              {"somehow file has vanished but write continues",
               fun(Title) ->
+                 %% External file-change detection (F6) now runs on a timer
+                 %% instead of on every write, so the test drives it
+                 %% explicitly with the same message the timer would send.
+                 %% Message order from this process to Pid is preserved, so
+                 %% the check is guaranteed to run before the notify below.
                  file:delete(LogFile),
+                 Pid ! '$eventlogger_check_file_changed',
                  ok = gen_event:sync_notify(Pid, {foo, <<"vanished111">>}), %% 20 bytes
                  FileData = file:read_file(LogFile),
                  State = gen_event:call(Pid, {eventlogger_file_writer, 1}, dump_state),
@@ -70,6 +81,7 @@ handler_with_maxbytes_test_() ->
               fun(Title) ->
                  ok = file:delete(LogFile),
                  ok = file:write_file(LogFile, <<"foo1\n">>, [write, raw]),
+                 Pid ! '$eventlogger_check_file_changed',
                  ok = gen_event:sync_notify(Pid, {foo, <<"foo2">>}), %% 12 bytes
                  FileData = file:read_file(LogFile),
                  State = gen_event:call(Pid, {eventlogger_file_writer, 1}, dump_state),

--- a/test/eventlogger_file_writer_tests.erl
+++ b/test/eventlogger_file_writer_tests.erl
@@ -113,7 +113,12 @@ handler_without_maxbytes_test_() ->
                                   [{event, foo},
                                    {file, LogFile},
                                    {modes, [append, raw, write]},
-                                   {count, 2}]),
+                                   {count, 2},
+                                   %% Long enough that the real timer never
+                                   %% fires during this test, so the
+                                   %% mismatched-ref case below can assert
+                                   %% timer_ref/wbytes deterministically.
+                                   {check_interval, 60000}]),
         [{tmpdir, TmpDir}, {logfile, LogFile}, {gen_event, Pid}]
      end,
      fun(Args) ->

--- a/test/eventlogger_file_writer_tests.erl
+++ b/test/eventlogger_file_writer_tests.erl
@@ -65,11 +65,17 @@ handler_with_maxbytes_test_() ->
               fun(Title) ->
                  %% External file-change detection (F6) now runs on a timer
                  %% instead of on every write, so the test drives it
-                 %% explicitly with the same message the timer would send.
-                 %% Message order from this process to Pid is preserved, so
-                 %% the check is guaranteed to run before the notify below.
+                 %% explicitly with the same {timeout, Ref, _} message the
+                 %% real timer would send (Ref must match the handler's own
+                 %% current timer_ref, since gen_event broadcasts handle_info
+                 %% to every installed handler -- see eventlogger_file_writer
+                 %% moduledoc). Message order from this process to Pid is
+                 %% preserved, so the check is guaranteed to run before the
+                 %% notify below.
                  file:delete(LogFile),
-                 Pid ! '$eventlogger_check_file_changed',
+                 #{timer_ref := TimerRef1} =
+                     gen_event:call(Pid, {eventlogger_file_writer, 1}, dump_state),
+                 Pid ! {timeout, TimerRef1, '$eventlogger_check_file_changed'},
                  ok = gen_event:sync_notify(Pid, {foo, <<"vanished111">>}), %% 20 bytes
                  FileData = file:read_file(LogFile),
                  State = gen_event:call(Pid, {eventlogger_file_writer, 1}, dump_state),
@@ -81,7 +87,9 @@ handler_with_maxbytes_test_() ->
               fun(Title) ->
                  ok = file:delete(LogFile),
                  ok = file:write_file(LogFile, <<"foo1\n">>, [write, raw]),
-                 Pid ! '$eventlogger_check_file_changed',
+                 #{timer_ref := TimerRef2} =
+                     gen_event:call(Pid, {eventlogger_file_writer, 1}, dump_state),
+                 Pid ! {timeout, TimerRef2, '$eventlogger_check_file_changed'},
                  ok = gen_event:sync_notify(Pid, {foo, <<"foo2">>}), %% 12 bytes
                  FileData = file:read_file(LogFile),
                  State = gen_event:call(Pid, {eventlogger_file_writer, 1}, dump_state),
@@ -150,6 +158,26 @@ handler_without_maxbytes_test_() ->
                                     "foobar555\n">>},
                                  FileData)},
                   {Title ++ ": state", ?_assertMatch(#{wbytes := 50}, State)}]
+              end},
+             {"a timer message belonging to another handler on the same "
+              "manager (mismatched ref) is ignored",
+              fun(Title) ->
+                 %% Several eventlogger_file_writer instances are typically
+                 %% installed on the same gen_event manager and all receive
+                 %% every raw message sent to it, so a foreign/mismatched
+                 %% timer ref must be a no-op rather than triggering a
+                 %% reopen or a reschedule.
+                 #{timer_ref := TimerRefBefore, wbytes := WBytesBefore} =
+                     gen_event:call(Pid, {eventlogger_file_writer, 1}, dump_state),
+                 ForeignRef = make_ref(),
+                 Pid ! {timeout, ForeignRef, '$eventlogger_check_file_changed'},
+                 ok = gen_event:sync_notify(Pid, {foo, <<"unaffected">>}),
+                 #{timer_ref := TimerRefAfter, wbytes := WBytesAfter} =
+                     gen_event:call(Pid, {eventlogger_file_writer, 1}, dump_state),
+                 [{Title ++ ": timer_ref is unchanged (no reschedule happened)",
+                   ?_assertEqual(TimerRefBefore, TimerRefAfter)},
+                  {Title ++ ": write still went through normally",
+                   ?_assertEqual(WBytesBefore + byte_size(<<"unaffected\n">>), WBytesAfter)}]
               end}],
         F = fun({Title, Test}) -> Test(Title) end,
         lists:map(F, Cases)

--- a/test/eventlogger_file_writer_tests.erl
+++ b/test/eventlogger_file_writer_tests.erl
@@ -68,10 +68,10 @@ handler_with_maxbytes_test_() ->
                  %% explicitly with the same {timeout, Ref, _} message the
                  %% real timer would send (Ref must match the handler's own
                  %% current timer_ref, since gen_event broadcasts handle_info
-                 %% to every installed handler -- see eventlogger_file_writer
-                 %% moduledoc). Message order from this process to Pid is
-                 %% preserved, so the check is guaranteed to run before the
-                 %% notify below.
+                 %% to every installed handler -- see the handle_info/2
+                 %% clause comments above). Message order from this process
+                 %% to Pid is preserved, so the check is guaranteed to run
+                 %% before the notify below.
                  file:delete(LogFile),
                  #{timer_ref := TimerRef1} =
                      gen_event:call(Pid, {eventlogger_file_writer, 1}, dump_state),


### PR DESCRIPTION
## 概要

voyagegroup/fluct_programmatic#762（reqres/eventlogger 群の直列化・コピー削減）の一環。fluct_dlv 側の RTB スループット頭打ち対策として、単一 gen_event ハンドラを通る reqres/auction ログ経路のコストを削る。ログ出力量・内容は不変。

## 変更内容

- **F29**: `eventlogger_file_writer:write_to_file/2` で区切り文字付加のために `Output0` 全体を新バイナリへコピーしていた処理を、`file:write/2` に iodata (`[Output0, Delimiter]`) を直接渡す形に変更し、全長 realloc を排除。
- **F6**: `handle_event/2` が毎イベント `file:read_file_info`(stat) で外部ファイル変更（ローテーション等）を検出していたのを、`check_interval`（デフォルト1000ms）のタイマーで定期的にのみ実行する方式に変更。書込みは常にキャッシュされた `io` へ直接行い、per-event の stat syscall を排除。

いずれも書込まれるバイト列・ローテーション挙動は不変（既存 eunit で確認）。F6 は外部変更の検知に最大 `check_interval` 分の遅延が生じるトレードオフあり。

バージョンは `0.0.4` に bump 済み。

## テスト

- `rebar3 eunit` — 55 tests, 0 failures
- `rebar3 xref` — クリーン

## 関連

- resolves voyagegroup/fluct_programmatic#762 の一部（eventlogger 側）
